### PR TITLE
Improve processing of author names

### DIFF
--- a/Pyblio/Format/Medline.py
+++ b/Pyblio/Format/Medline.py
@@ -107,42 +107,35 @@ class MedlineIterator (Iterator.Iterator):
             group = Fields.AuthorGroup ()
             
             for au in table ['AU']:
-                # analyze the author by ourself.
+                # analyze the author names
                 first, last, lineage = [], [], []
                 
-                for part in string.split (au, ' '):
-		    if part.isupper ():
-                        # in upper-case, this is a first name
-                        if len (last) > 0:
-                            first.append (part)
-                        else:
-                            # if there is no last name, there can't be a first name
-                            last.append (part)
-                    else:
-                        if len (first) > 0:
-                            # there was a first name, this must be a lineage
-                            lineage.append (part)
-                        else:
-                            last.append (part)
+                parts = string.split (au, ' ')
 
-                if len (first) > 1:
-                    print "medline: long first name found. skipping."
-                    first = first [0:1]
+                # if the last part is not uppercase, it is a lineage ('Jr', '3rd', etc.)
+                if not parts [-1] . isupper():
+                    lineage.append (parts.pop ())
+                else:
+                    lineage = None
 
-                if len (first) > 0:
-                    first = string.join (first [0], '. ') + '.'
+                # after removing lineage from list, last part should be the first initial(s)
+                if len (parts) > 1:
+                    first = parts.pop ()
+                    first = string.join (first, '. ') + '.'
                 else:
                     first = None
 
-                if len (last) > 0:
-                    last = string.join (last, ' ')
+                # join remaining parts to form the last name. if it's one initial, give it a '.'
+                for part in parts:
+                    if len (part) == 1:
+                        last.append (part + '.')
+                    else:
+                        last.append (part)
+
+                if len (parts) > 0:
+                    last = string.join(last, ' ')
                 else:
                     last = None
-
-                if len (lineage) > 0:
-                    lineage = string.join (lineage, ' ')
-                else:
-                    lineage = None
                     
                 group.append (Fields.Author ((None, first, last, lineage)))
                 

--- a/Pyblio/Utils.py
+++ b/Pyblio/Utils.py
@@ -95,11 +95,13 @@ def generate_key (entry, table):
     else:
         if len (aut) > 1:
             key = ''
+            keynum = 0
             for a in aut:
                 honorific, first, last, lineage = a.format ()
                 key = key + join (map (lambda x:
                                        x [0], split (last, ' ')), '')
-                if len (key) >= 3:
+                keynum += 1
+                if keynum >= 3:
                     if len (aut) > 3:
                         key = key + '+'
                     break


### PR DESCRIPTION
In the MEDLINE AU field, the first initials are always a single string, so there should never be a multi-word first name. If there is more than one string preceding the first initials and lineage, it means that the last name contains multiple words. This edit allows for correct processing of multi-word last names. If one of the words in the last name is a single character, it is given a '.' because it is probably an abbreviation.

See for example the multi-word last names in these MEDLINE entries:
  http://www.ncbi.nlm.nih.gov/pubmed?Db=pubmed&Cmd=Retrieve&list_uids=24701472&dopt=medline
  http://www.ncbi.nlm.nih.gov/pubmed?Db=pubmed&Cmd=Retrieve&list_uids=24701509&dopt=medline
